### PR TITLE
Refined the architecture with ports, a composition root, and stricter configuration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,27 @@ The project follows a layered package structure:
 - `pdf_reader.entrypoints`
   CLI-facing entrypoints for local execution
 
-This repository currently uses a layered architecture. The empty legacy `layers/` folder is not part of the runtime design.
+This repository currently uses a layered architecture with a small composition root. The empty legacy `layers/` folder is not part of the runtime design.
 
 ### Processing Flow
 
 1. Load runtime configuration from an explicit config file
 2. Load block-detection rules from the configured `doc_type.json`
-3. Extract lines from PDFs through the infrastructure extractor
-4. Classify lines into logical blocks in the domain layer
-5. Persist the final XML output
+3. Compose concrete adapters in the bootstrap/composition root
+4. Extract lines from PDFs through the infrastructure extractor
+5. Classify lines into logical blocks in the domain layer
+6. Persist the final XML output
 
 ## Repository Layout
 
 ```text
 pdf_reader/
+  bootstrap.py
   application/
     cleanup_output.py
     compare_outputs.py
     config.py
+    ports.py
     generate_doc_type.py
     process_pdf_batch.py
   domain/
@@ -240,6 +243,12 @@ Defines:
 - regex match rules
 - minimum font thresholds
 - ignored text prefixes
+
+The supported schema is now strict and uses the English keys `structures`, `blocks`, `ignore`, and `minimum_description_font_size`.
+
+### Legacy compatibility
+
+`MuPdfBlockExtractor` is kept only as a legacy compatibility wrapper. New integrations should use the main `PdfBatchProcessor` flow through the composition root in `pdf_reader/bootstrap.py`.
 
 ## Development
 

--- a/pdf_reader/application/ports.py
+++ b/pdf_reader/application/ports.py
@@ -1,0 +1,29 @@
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from pdf_reader.domain.models import BlockContent, DocumentTypeConfig, LineData
+
+
+class LineExtractor(Protocol):
+    def extract_lines(self, pdf_path: str) -> list[LineData]:
+        ...
+
+
+class DocumentTypeConfigLoader(Protocol):
+    def load(self, doc_type_path: str) -> DocumentTypeConfig:
+        ...
+
+
+class BlockWriter(Protocol):
+    def start_document(self) -> None:
+        ...
+
+    def write_block(self, block: BlockContent) -> None:
+        ...
+
+    def finish_document(self) -> None:
+        ...
+
+
+BlockWriterFactory = Callable[[str], BlockWriter]
+PdfPathCollection = Iterable[str]

--- a/pdf_reader/application/process_pdf_batch.py
+++ b/pdf_reader/application/process_pdf_batch.py
@@ -3,27 +3,31 @@ import time
 
 from pdf_reader.domain.models import BlockContent
 from pdf_reader.domain.services import BlockDetector
-from pdf_reader.infrastructure.config_loader import JsonDocumentTypeConfigLoader
-from pdf_reader.infrastructure.extractors.pymupdf_extractor import PyMuPdfLineExtractor
-from pdf_reader.infrastructure.writers.xml_writer import XmlBlockWriter
+from pdf_reader.application.ports import BlockWriter, BlockWriterFactory, DocumentTypeConfigLoader, LineExtractor
 
 
 class PdfBatchProcessor:
-    def __init__(self, line_extractor: PyMuPdfLineExtractor | None = None, config_loader: JsonDocumentTypeConfigLoader | None = None):
-        self._line_extractor = line_extractor or PyMuPdfLineExtractor()
-        self._config_loader = config_loader or JsonDocumentTypeConfigLoader()
+    def __init__(
+        self,
+        line_extractor: LineExtractor,
+        config_loader: DocumentTypeConfigLoader,
+        writer_factory: BlockWriterFactory,
+    ):
+        self._line_extractor = line_extractor
+        self._config_loader = config_loader
+        self._writer_factory = writer_factory
 
     def process(self, pdf_paths: list[str], output_xml_path: str, doc_type_path: str) -> None:
         config = self._config_loader.load(doc_type_path)
         detector = BlockDetector(config)
-        writer = XmlBlockWriter(output_xml_path)
+        writer = self._writer_factory(output_xml_path)
 
         writer.start_document()
         for pdf_path in pdf_paths:
             self._process_single_pdf(pdf_path, detector, writer)
         writer.finish_document()
 
-    def _process_single_pdf(self, pdf_path: str, detector: BlockDetector, writer: XmlBlockWriter) -> None:
+    def _process_single_pdf(self, pdf_path: str, detector: BlockDetector, writer: BlockWriter) -> None:
         current_block_name: str | None = None
         current_text = ""
 

--- a/pdf_reader/bootstrap.py
+++ b/pdf_reader/bootstrap.py
@@ -1,0 +1,12 @@
+from pdf_reader.application.process_pdf_batch import PdfBatchProcessor
+from pdf_reader.infrastructure.config_loader import JsonDocumentTypeConfigLoader
+from pdf_reader.infrastructure.extractors.pymupdf_extractor import PyMuPdfLineExtractor
+from pdf_reader.infrastructure.writers.xml_writer import XmlBlockWriter
+
+
+def create_pdf_batch_processor() -> PdfBatchProcessor:
+    return PdfBatchProcessor(
+        line_extractor=PyMuPdfLineExtractor(),
+        config_loader=JsonDocumentTypeConfigLoader(),
+        writer_factory=XmlBlockWriter,
+    )

--- a/pdf_reader/entrypoints/process_pdf.py
+++ b/pdf_reader/entrypoints/process_pdf.py
@@ -1,7 +1,8 @@
 import os
 
 from pdf_reader.application.config import load_runtime_config
-from pdf_reader.application.process_pdf_batch import PdfBatchProcessor, collect_pdf_paths, run_processing_job
+from pdf_reader.application.process_pdf_batch import collect_pdf_paths, run_processing_job
+from pdf_reader.bootstrap import create_pdf_batch_processor
 from pdf_reader.entrypoints._cli import parse_config_path
 
 
@@ -31,7 +32,7 @@ def main():
     doc_type_path = config.processing.doc_type_path
 
     print(f"Processing {len(pdf_files)} PDF files...")
-    processor = PdfBatchProcessor()
+    processor = create_pdf_batch_processor()
     run_processing_job(processor, pdf_files, output_xml_path, doc_type_path, "PyMuPDF")
 
 

--- a/pdf_reader/infrastructure/config_loader.py
+++ b/pdf_reader/infrastructure/config_loader.py
@@ -8,27 +8,51 @@ class JsonDocumentTypeConfigLoader:
         with open(doc_type_path, "r", encoding="utf-8") as file:
             doc_type = json.load(file)
 
-        for category in doc_type.values():
-            if not isinstance(category, dict):
-                continue
+        if not isinstance(doc_type, dict):
+            raise ValueError("Document type configuration must be a JSON object.")
 
-            blocks_key = "blocks" if "blocks" in category else "blocos" if "blocos" in category else None
-            ignore_key = "ignore" if "ignore" in category else "ignorar" if "ignorar" in category else None
+        if "structures" not in doc_type:
+            raise ValueError("Document type configuration must contain a top-level 'structures' object.")
 
-            if blocks_key and ignore_key:
-                rules = {
-                    block_name: BlockRule(
-                        match=block_config.get("match", []),
-                        minimum_description_font_size=block_config.get(
-                            "minimum_description_font_size",
-                            block_config.get("descricao_fonte_minima", 0),
-                        ),
-                    )
-                    for block_name, block_config in category.get(blocks_key, {}).items()
-                }
-                return DocumentTypeConfig(
-                    blocks=rules,
-                    ignore=set(category.get(ignore_key, [])),
-                )
+        structures = doc_type["structures"]
+        if not isinstance(structures, dict):
+            raise ValueError("'structures' must be a JSON object.")
 
-        return DocumentTypeConfig()
+        if "blocos" in structures or "ignorar" in structures:
+            raise ValueError("Portuguese document type keys are no longer supported. Use 'blocks' and 'ignore'.")
+
+        if "blocks" not in structures or "ignore" not in structures:
+            raise ValueError("'structures' must define both 'blocks' and 'ignore'.")
+
+        blocks = structures["blocks"]
+        ignore = structures["ignore"]
+
+        if not isinstance(blocks, dict):
+            raise ValueError("'blocks' must be a JSON object keyed by block name.")
+        if not isinstance(ignore, list):
+            raise ValueError("'ignore' must be a JSON array of prefixes.")
+
+        rules = {
+            block_name: self._build_block_rule(block_name, block_config)
+            for block_name, block_config in blocks.items()
+        }
+        return DocumentTypeConfig(blocks=rules, ignore=set(ignore))
+
+    def _build_block_rule(self, block_name: str, block_config: dict) -> BlockRule:
+        if not isinstance(block_config, dict):
+            raise ValueError(f"Block '{block_name}' must be a JSON object.")
+
+        match = block_config.get("match")
+        if not isinstance(match, list) or not all(isinstance(pattern, str) for pattern in match):
+            raise ValueError(f"Block '{block_name}' must define 'match' as a list of regex strings.")
+
+        minimum_description_font_size = block_config.get("minimum_description_font_size", 0)
+        if not isinstance(minimum_description_font_size, (int, float)):
+            raise ValueError(
+                f"Block '{block_name}' must define 'minimum_description_font_size' as a number when present."
+            )
+
+        return BlockRule(
+            match=match,
+            minimum_description_font_size=float(minimum_description_font_size),
+        )

--- a/pdf_reader/infrastructure/extractors/mupdf_block_extractor.py
+++ b/pdf_reader/infrastructure/extractors/mupdf_block_extractor.py
@@ -1,3 +1,6 @@
+import warnings
+
+from pdf_reader.bootstrap import create_pdf_batch_processor
 from pdf_reader.application.process_pdf_batch import PdfBatchProcessor
 from pdf_reader.domain.models import BlockContent, LineData
 from pdf_reader.domain.services import BlockDetector, serialize_block
@@ -5,13 +8,21 @@ from pdf_reader.infrastructure.config_loader import JsonDocumentTypeConfigLoader
 
 
 class MuPdfBlockExtractor:
+    """Legacy compatibility wrapper around the main PDF batch processor."""
+
     def __init__(self, pdf_paths, output_xml_path, doc_type_path):
+        warnings.warn(
+            "MuPdfBlockExtractor is a legacy compatibility wrapper. "
+            "Prefer PdfBatchProcessor via the composition root for new integrations.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.pdf_paths = pdf_paths
         self.output_xml_path = output_xml_path
         self.doc_type_path = doc_type_path
         self._config = None
         self._detector = None
-        self._processor = PdfBatchProcessor()
+        self._processor = create_pdf_batch_processor()
         self.block_config = {}
         self.ignored_texts = set()
         self.block_order = []

--- a/pdf_reader/infrastructure/extractors/pymupdf_extractor.py
+++ b/pdf_reader/infrastructure/extractors/pymupdf_extractor.py
@@ -5,31 +5,30 @@ from pdf_reader.domain.models import LineData
 
 class PyMuPdfLineExtractor:
     def extract_lines(self, pdf_path: str) -> list[LineData]:
-        document = fitz.open(pdf_path)
         lines: list[LineData] = []
 
-        for page in document:
-            blocks = page.get_text("dict")["blocks"]
-            for block in blocks:
-                if "lines" not in block:
-                    continue
-
-                for line in block["lines"]:
-                    spans = line["spans"]
-                    if not spans:
+        with fitz.open(pdf_path) as document:
+            for page in document:
+                blocks = page.get_text("dict")["blocks"]
+                for block in blocks:
+                    if "lines" not in block:
                         continue
 
-                    text = " ".join(span["text"] for span in spans).strip()
-                    if not text:
-                        continue
+                    for line in block["lines"]:
+                        spans = line["spans"]
+                        if not spans:
+                            continue
 
-                    lines.append(
-                        LineData(
-                            text=text,
-                            font_size=max(span["size"] for span in spans),
-                            is_bold=any("bold" in span.get("font", "").lower() for span in spans),
+                        text = " ".join(span["text"] for span in spans).strip()
+                        if not text:
+                            continue
+
+                        lines.append(
+                            LineData(
+                                text=text,
+                                font_size=max(span["size"] for span in spans),
+                                is_bold=any("bold" in span.get("font", "").lower() for span in spans),
+                            )
                         )
-                    )
 
-        document.close()
         return lines

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -11,28 +11,41 @@ class FakeExtractor:
         ]
 
 
-def test_pdf_batch_processor_uses_layers(tmp_path):
-    doc_type_path = tmp_path / "doc_type.json"
-    doc_type_path.write_text(
-        """
-{
-  "structures": {
-    "blocks": {
-      "Title": {
-        "match": ["^title"],
-        "minimum_description_font_size": 10
-      }
-    },
-    "ignore": ["end"]
-  }
-}
-        """.strip(),
-        encoding="utf-8",
-    )
+class FakeConfigLoader:
+    def load(self, doc_type_path: str):
+        from pdf_reader.domain.models import BlockRule, DocumentTypeConfig
 
+        return DocumentTypeConfig(
+            blocks={"Title": BlockRule(match=[r"^title"], minimum_description_font_size=10)},
+            ignore={"end"},
+        )
+
+
+class FakeWriter:
+    def __init__(self, output_path: str):
+        self.output_path = output_path
+
+    def start_document(self) -> None:
+        with open(self.output_path, "w", encoding="utf-8") as file:
+            file.write("<data>\n")
+
+    def write_block(self, block) -> None:
+        with open(self.output_path, "a", encoding="utf-8") as file:
+            file.write(f"  <{block.name}>{block.text}</{block.name}>\n")
+
+    def finish_document(self) -> None:
+        with open(self.output_path, "a", encoding="utf-8") as file:
+            file.write("</data>\n")
+
+
+def test_pdf_batch_processor_uses_layers(tmp_path):
     output_path = tmp_path / "output.xml"
-    processor = PdfBatchProcessor(line_extractor=FakeExtractor())
-    processor.process(["fake.pdf"], str(output_path), str(doc_type_path))
+    processor = PdfBatchProcessor(
+        line_extractor=FakeExtractor(),
+        config_loader=FakeConfigLoader(),
+        writer_factory=FakeWriter,
+    )
+    processor.process(["fake.pdf"], str(output_path), "unused.json")
 
     content = output_path.read_text(encoding="utf-8")
     assert "<data>" in content

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 from pdf_reader.application.config import build_runtime_config, load_runtime_config
+from pdf_reader.infrastructure.config_loader import JsonDocumentTypeConfigLoader
 
 
 def test_build_runtime_config_uses_explicit_values():
@@ -150,3 +151,39 @@ def test_load_runtime_config_expands_env_placeholders(tmp_path, monkeypatch):
     assert config is not None
     assert config.input_dir == str((tmp_path / "placeholder-input").resolve())
     assert config.output_dir == str((tmp_path / "placeholder-output").resolve())
+
+
+def test_document_type_config_loader_requires_structures_root(tmp_path):
+    path = tmp_path / "doc_type.json"
+    path.write_text('{"blocks": {}}', encoding="utf-8")
+
+    loader = JsonDocumentTypeConfigLoader()
+
+    try:
+        loader.load(str(path))
+        assert False, "Expected ValueError for missing 'structures' root"
+    except ValueError as error:
+        assert "top-level 'structures'" in str(error)
+
+
+def test_document_type_config_loader_rejects_portuguese_keys(tmp_path):
+    path = tmp_path / "doc_type.json"
+    path.write_text(
+        """
+{
+  "structures": {
+    "blocos": {},
+    "ignorar": []
+  }
+}
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    loader = JsonDocumentTypeConfigLoader()
+
+    try:
+        loader.load(str(path))
+        assert False, "Expected ValueError for Portuguese keys"
+    except ValueError as error:
+        assert "no longer supported" in str(error)

--- a/tests/test_mupdf_block_extractor.py
+++ b/tests/test_mupdf_block_extractor.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from pdf_reader.infrastructure.extractors.mupdf_block_extractor import MuPdfBlockExtractor
 
@@ -20,7 +21,9 @@ def test_detect_block(tmp_path):
         json.dump(doc_type, file, ensure_ascii=False)
 
     output_xml_path = tmp_path / "output.xml"
-    parser = MuPdfBlockExtractor([], str(output_xml_path), str(doc_type_path))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        parser = MuPdfBlockExtractor([], str(output_xml_path), str(doc_type_path))
     assert parser.detect_block("Title of Document", 11) == "Title"
     assert parser.detect_block("No block", 11) is None
 
@@ -31,8 +34,23 @@ def test_write_xml_entry(tmp_path):
         json.dump({"structures": {"blocks": {}, "ignore": []}}, file, ensure_ascii=False)
 
     output_xml_path = tmp_path / "output.xml"
-    parser = MuPdfBlockExtractor([], str(output_xml_path), str(doc_type_path))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        parser = MuPdfBlockExtractor([], str(output_xml_path), str(doc_type_path))
     parser.save_xml_entry("My Block (1)", "Text <a> & test")
     with open(output_xml_path, "r", encoding="utf-8") as file:
         content = file.read()
     assert "<My_Block_1>Text &lt;a&gt; &amp; test</My_Block_1>" in content
+
+
+def test_legacy_extractor_emits_deprecation_warning(tmp_path):
+    doc_type_path = tmp_path / "doc_type.json"
+    with open(doc_type_path, "w", encoding="utf-8") as file:
+        json.dump({"structures": {"blocks": {}, "ignore": []}}, file, ensure_ascii=False)
+
+    output_xml_path = tmp_path / "output.xml"
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        MuPdfBlockExtractor([], str(output_xml_path), str(doc_type_path))
+
+    assert any(item.category is DeprecationWarning for item in captured)


### PR DESCRIPTION
## Context

This PR strengthens the project architecture without introducing unnecessary complexity.

Key changes:
- introduces lightweight interfaces/protocols in the application layer
- moves the composition of concrete adapters to a composition root
- defines `MuPdfBlockExtractor` as a legacy compatibility wrapper
- enforces stricter validation of `doc_type.json`
- improves resource management in the extractor
- updates tests and README

---

## What Changed

### Architecture
- Added `pdf_reader/application/ports.py` with lightweight contracts for:
  - line extraction
  - document type configuration loading
  - block writing
- Refactored `PdfBatchProcessor` to depend on contracts instead of concrete infrastructure implementations
- Added `pdf_reader/bootstrap.py` as a simple composition root
- Updated the `process_pdf` entrypoint to build the processor via the composition root

---

### Legacy Boundary
- `MuPdfBlockExtractor` was kept as a compatibility wrapper
- Added `DeprecationWarning` to explicitly mark it as legacy
- Previous behavior was preserved for existing integrations

---

### Configuration Validation
- `JsonDocumentTypeConfigLoader` now performs stricter validation
- Requires top-level key: `structures`
- Requires English keys:
  - `blocks`
  - `ignore`
  - `minimum_description_font_size`
- Rejects legacy keys instead of accepting mixed schemas

---

### Reliability
- `PyMuPdfLineExtractor` now uses deterministic resource management via a context manager

---

### Tests and Documentation
- Updated tests to validate:
  - processor behavior with dependency injection
  - deprecation warning of the legacy wrapper
  - strict schema validation
- Updated README to reflect:
  - composition root usage
  - supported schema
  - guidance on legacy compatibility

---

## Motivation

Before this change, the application layer still directly instantiated concrete infrastructure dependencies, weakening the separation between layers.  

This PR improves decoupling while keeping the project small, readable, and easy to evolve.

---

## Validation

Successfully executed:
- `python -m compileall pdf_reader tests`
- manual loader testing with the new strict schema

---

## Risks and Notes

- `doc_type.json` validation is now intentionally stricter  
- legacy keys are no longer accepted by the loader  
- `MuPdfBlockExtractor` remains available only for compatibility, but new integrations should use the main flow with `PdfBatchProcessor`  

---

## Possible Next Steps

- add integration tests for concrete adapters  
- create more complete CLI tests  
- remove the legacy wrapper in a future cleanup  